### PR TITLE
npm config tmp should have precedence over /tmp

### DIFF
--- a/install.js
+++ b/install.js
@@ -124,8 +124,8 @@ npmconf.load(function(err, conf) {
 function findSuitableTempDirectory(npmTmpDir) {
   var now = Date.now();
   var candidateTmpDirs = [
-    process.env.TMPDIR || '/tmp',
-    npmTmpDir,
+    process.env.TMPDIR || npmTmpDir,
+    '/tmp',
     path.join(process.cwd(), 'tmp')
   ];
 


### PR DESCRIPTION
Previously /tmp would always be tried before `npmConf.get('tmp')`
